### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a simple project to provide MAAS with KVM POD capability in a LXD contai
 - KVM must be installed and working. [KVM Install Guide](https://help.ubuntu.com/community/KVM/Installation)
 
 ## Running
+If using a version of lxd that supports storage pools (>2.0), ensure that the pool name in 'root-device' matches what you have in `lxc storage list`
+
 Run the make-maas.sh and name your MAAS container.
 ```
 ./make-maas.sh maas
@@ -18,7 +20,7 @@ MAAS. If you're using a bridged network setup you'll need to handle network
 configuration to address how you want DHCP/DNS/PXE to be routed.
 
 The install can take some time as it has to install several packages. When it is
-complete you can access your MAAS node at http://MAASIP/MAAS
+complete you can access your MAAS node at http://MAASIP:5240/MAAS
 
 ## Using MAAS
 See the [MAAS Documentation](https://docs.ubuntu.com/maas/devel/en/) for up to

--- a/make-maas.sh
+++ b/make-maas.sh
@@ -34,4 +34,4 @@ else
     lxc network set lxdbr0 raw.dnsmasq dhcp-boot=pxelinux.0,$CONTAINER,$IPADDRESS && systemctl restart lxd.service
 fi
 
-echo "MAAS will become available at: http://$IPADDRESS/MAAS with user/password admin/admin"
+echo "MAAS will become available at: http://$IPADDRESS:5240/MAAS with user/password admin/admin"


### PR DESCRIPTION
My make-maas failed since the default lxc storage pool was called 'lxc' instead of 'default'.
I also couldn't hit http://IPADDRESS/MAAS without adding the port that it's listening on, as the apache config on the container is bare and just has the default pages enabled.