### PR TITLE
Updates for running on newer LXDs and Cosmic (LXD snap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a simple project to provide MAAS with KVM POD capability in a LXD contai
 ## Getting Started
 - LXD must be installed and working. [LXD Install Guide](https://linuxcontainers.org/lxd/getting-started-cli/)
 - KVM must be installed and working. [KVM Install Guide](https://help.ubuntu.com/community/KVM/Installation)
+- If running LXC version 3.0 or above, ensure that you have an LXD
+  storage pool named "default" set up; this project assumes it is.
 
 ## Running
 If using a version of lxd that supports storage pools (>2.0), ensure that the pool name in 'root-device' matches what you have in `lxc storage list`


### PR DESCRIPTION
Specifics:

* Minor doc update, mentioning the dependency on the "default" pool.  This was more of a soft dependency in the past, but make-maas.sh presently uses a hardcoded "default" pool in one of its commands in addition to the "default" pool in root-device.  It'd be nice to parameterize this bit, but for now I've opted to not do so.

* For systems running LXD via a snap, you'd get an error message on the "systemctl restart lxd.service".  I first tried to enable a similar command on Cosmic, but then found that it seemed to interfere with being able to start the MAAS container successfully.  I've added some code with comments regarding this; I'd like your input.