### PR TITLE
Add vhost-net to maas-profile

### DIFF
--- a/maas-profile
+++ b/maas-profile
@@ -74,6 +74,9 @@ devices:
   kvm:
     path: /dev/kvm
     type: unix-char
+  vhost-net:
+    path: /dev/vhost-net
+    type: unix-char
   loop0:
     path: /dev/loop0
     type: unix-block


### PR DESCRIPTION
vhost-net is needed to allow kvm get better network performance.