### PR TITLE
Allow user to pass pod compose details

### DIFF
--- a/create-vm-pod.sh
+++ b/create-vm-pod.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 CONTAINER=$1
+shift
+if [ "$#" -eq 0 ]; then
+    POD_SPECS="cores=2 memory=2048 storage=20"
+else
+    POD_SPECS="$@"
+fi
 
 IPADDRESS=$(lxc info $CONTAINER | awk -F"[: \t]+" '/eth0:.*inet[^6]/ {print $4}')
 
@@ -10,5 +16,5 @@ lxc exec $CONTAINER -- maas login admin http://$IPADDRESS:5240/MAAS $APIKEY
 echo "Creating POD"
 lxc exec $CONTAINER -- maas admin pods create type=virsh power_address=qemu:///system
 
-echo "Creating Machine"
-lxc exec $CONTAINER -- maas admin pod compose 1 cores=2 memory=2048 storage=20
+echo "Creating Machine(s) with specs: $POD_SPECS"
+lxc exec $CONTAINER -- maas admin pod compose 1 $POD_SPECS


### PR DESCRIPTION
create-vm-pod.sh by default was creating a machine with 2 core, 2G
memory and 20G of storage, with this patch a user could pass their own
spec, for example:

  ./create-vm-pod.sh maas-container cores=5 memory=4096 storage=50