### PR TITLE
Add helper scripts to register maas in juju and bootstrap

### DIFF
--- a/juju/bootstrap.sh
+++ b/juju/bootstrap.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+juju bootstrap --constraints "mem=2G" --show-log maas-cloud

--- a/juju/register-cloud.sh
+++ b/juju/register-cloud.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+which juju || (echo "juju is not installed: snap install --classic juju"; exit 1)
+CONTAINER=$1
+IPADDRESS=$(lxc info $CONTAINER | awk -F"[: \t]+" '/eth0:.*inet[^6]/ {print $4}')
+APIKEY=$(lxc exec $CONTAINER -- maas apikey --username admin)
+TMPFILE=$(mktemp)
+cat << EOF > $TMPFILE
+clouds:         # clouds key is required.
+  maas-cloud:   # cloud's name
+    type: maas
+    auth-types: [oauth1]
+    endpoint: http://__IPADDRESS__:5240/MAAS
+EOF
+sed -i s/__IPADDRESS__/$IPADDRESS/g $TMPFILE
+juju add-cloud --local maas-cloud $TMPFILE
+
+cat << EOF > $TMPFILE
+credentials:
+  maas-cloud:
+    admin:
+      auth-type: oauth1
+      maas-oauth: __APIKEY__
+EOF
+sed -i s/__APIKEY__/$APIKEY/g $TMPFILE
+juju add-credential maas-cloud -f $TMPFILE
+rm $TMPFILE


### PR DESCRIPTION
- juju/register-cloud.sh: calls juju add-cloud and add-credential to
register this maas installation under the name 'maas-cloud'
- juju/bootstrap.sh: runs juju bootstrap requesting a machine with 2G of
memory.